### PR TITLE
Javadoc

### DIFF
--- a/src/main/java/ome/annotations/AnnotationUtils.java
+++ b/src/main/java/ome/annotations/AnnotationUtils.java
@@ -1,6 +1,4 @@
 /*
- * ome.annotations.AnnotationUtils
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,8 +12,8 @@ import ome.conditions.InternalException;
 /**
  * Checks metadata constraints on API calls.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/annotations/ApiConstraintChecker.java
+++ b/src/main/java/ome/annotations/ApiConstraintChecker.java
@@ -1,6 +1,4 @@
 /*
- * ome.annotations.ApiConstraintChecker
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -20,8 +18,8 @@ import ome.conditions.ValidationException;
 /**
  * Checks metadata constraints on API calls.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/annotations/NotNull.java
+++ b/src/main/java/ome/annotations/NotNull.java
@@ -1,6 +1,4 @@
 /*
- * ome.annotations.Validate
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,8 +12,8 @@ import java.lang.annotation.Target;
 /**
  * annotation used for determining the types of a Set
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/annotations/Validate.java
+++ b/src/main/java/ome/annotations/Validate.java
@@ -1,6 +1,4 @@
 /*
- * ome.annotations.Validate
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,8 +12,8 @@ import java.lang.annotation.Target;
 /**
  * annotation used for determining the types of a Set
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 1.0
  * @since 1.0
  */

--- a/src/main/java/ome/api/IAdmin.java
+++ b/src/main/java/ome/api/IAdmin.java
@@ -34,8 +34,8 @@ import ome.system.Roles;
  * {@link ome.model.meta.Experimenter}, respectively.
  * 
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @since OME3.0
  */
 public interface IAdmin extends ServiceInterface {

--- a/src/main/java/ome/api/IAnalysis.java
+++ b/src/main/java/ome/api/IAnalysis.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.IAnalysis
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -19,8 +17,8 @@ import ome.model.core.Image;
  * suggestions from Harry.
  * 
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since OME3.0
  */

--- a/src/main/java/ome/api/IContainer.java
+++ b/src/main/java/ome/api/IContainer.java
@@ -400,8 +400,8 @@ public interface IContainer extends ServiceInterface {
      * <p>
      * To link or unlink objects to the specified object, we should call the
      * methods link or unlink. TODO Or do we use for example
-     * dataset.setProjects(set of projects) to add. Tink has to be set as
-     * follows dataset->project and project->dataset.
+     * dataset.setProjects(set of projects) to add. Link has to be set as
+     * follows dataset to project and project to dataset.
      * 
      * Alternatively, you can make sure that the collection is <b>exactly</b>
      * how it should be in the database. If you can't guarantee this, it's best

--- a/src/main/java/ome/api/IContainer.java
+++ b/src/main/java/ome/api/IContainer.java
@@ -83,11 +83,11 @@ import ome.parameters.Parameters;
  * the userGroupId for the newly created objects. TODO umask.
  * </p>
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 1.0
  * @since OME1.0
  * TODO possibly move optionBuilder to the common code. ome.common.utils

--- a/src/main/java/ome/api/ILdap.java
+++ b/src/main/java/ome/api/ILdap.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.ILdap
- *
  *   Copyright 2006 - 2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -24,8 +22,8 @@ import ome.model.meta.ExperimenterGroup;
  * {@link ome.model.meta.Experimenter}, respectively.
  *
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @since OME3.0
  */
 public interface ILdap extends ServiceInterface {

--- a/src/main/java/ome/api/IPixels.java
+++ b/src/main/java/ome/api/IPixels.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.IPixels
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -24,17 +22,17 @@ import ome.model.stats.StatsInfo;
  * needs as well as Pixels services to a client. It also allows the rendering 
  * engine to also be run external to the server (e.g. client-side).
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk">a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk">a.falconi@dundee.ac.uk</a>
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @author <br>
- *         Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ *         Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since OME2.2
  */

--- a/src/main/java/ome/api/IProjection.java
+++ b/src/main/java/ome/api/IProjection.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -15,8 +13,8 @@ import ome.model.enums.PixelsType;
 /**
  * Provides methods for performing projections of Pixels sets.
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/api/IProjection.java
+++ b/src/main/java/ome/api/IProjection.java
@@ -65,7 +65,7 @@ public interface IProjection extends ServiceInterface
      *   <li><code>channelIndex</code> is out of range</li>
      *   <li><code>start</code> is out of range</li>
      *   <li><code>end</code> is out of range</li>
-     *   <li><code>start > end</code></li>
+     *   <li><code>start</code> is greater than <code>end</code></li>
      *   <li>the Pixels set qualified by <code>pixelsId</code> is unlocatable.</li>
      * </ul>
      * @see #projectPixels(long, PixelsType, int, int, int, List, int, int, int, String)
@@ -109,11 +109,11 @@ public interface IProjection extends ServiceInterface
      *   <li><code>algorithm</code> is unknown</li>
      *   <li><code>tStart</code> is out of range</li>
      *   <li><code>tEnd</code> is out of range</li>
-     *   <li><code>tStart > tEnd</code></li>
+     *   <li><code>tStart</code> is greater than <code>tEnd</code></li>
      *   <li><code>channels</code> is null or has indexes out of range</li>
      *   <li><code>zStart</code> is out of range</li>
      *   <li><code>zEnd</code> is out of range</li>
-     *   <li><code>zStart > zEnd</code></li>
+     *   <li><code>zStart</code> is greater than <code>zEnd</code></li>
      *   <li>the Pixels set qualified by <code>pixelsId</code> is unlocatable.</li>
      * </ul>
      * @see #projectStack(long, PixelsType, int, int, int, int, int start, int)

--- a/src/main/java/ome/api/IQuery.java
+++ b/src/main/java/ome/api/IQuery.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.IQuery
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -28,8 +26,8 @@ import ome.parameters.QueryParameter;
  * return a null or empty {@link java.util.Collection}, but instead will throw
  * a {@link ome.conditions.ValidationException}.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since 3.0
  * @see Filter

--- a/src/main/java/ome/api/IRenderingSettings.java
+++ b/src/main/java/ome/api/IRenderingSettings.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.IRenderingSettings
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -22,8 +20,8 @@ import ome.model.display.RenderingDef;
  * All methods will receive the id of the pixels set to copy the rendering
  * settings from.
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/api/IRepositoryInfo.java
+++ b/src/main/java/ome/api/IRepositoryInfo.java
@@ -23,8 +23,8 @@ import ome.conditions.InternalException;
  * Use is subject to license terms supplied in LICENSE.txt 
  * </p>
  *
- * @author David L. Whitehurst &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:david@glencoesoftware.com">david@glencoesoftware.com</a>
+ * @author David L. Whitehurst &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:david@glencoesoftware.com">david@glencoesoftware.com</a>
  * @version $Revision$
  * @since 3.0
  */

--- a/src/main/java/ome/api/IScale.java
+++ b/src/main/java/ome/api/IScale.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -12,8 +10,8 @@ import java.awt.image.BufferedImage;
  * Provides methods for performing scaling (change of the image size through
  * interpolation or other means) on BufferedImages.
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/api/ITypes.java
+++ b/src/main/java/ome/api/ITypes.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.ITypes
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -20,8 +18,8 @@ import ome.model.IEnum;
  * Access to reflective type information. Also provides simplified access to
  * special types like enumerations.
  * 
- * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
+ * @author Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de">josh.moore@gmx.de</a>
  * @version 3.0
  * @since OMERO3
  */

--- a/src/main/java/ome/api/IUpdate.java
+++ b/src/main/java/ome/api/IUpdate.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.IUpdate
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -44,8 +42,8 @@ import ome.model.IObject;
  * already been incremented.
  * 
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 3.0
  * @since OMERO3.0
  * @see ome.util.Validation

--- a/src/main/java/ome/api/RawFileStore.java
+++ b/src/main/java/ome/api/RawFileStore.java
@@ -1,6 +1,4 @@
 /*
- * ome.services.RawFileStore
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,8 +11,8 @@ import ome.model.core.OriginalFile;
 /**
  * Raw file gateway which provides access to the OMERO file repository.
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since OMERO3.0
  */

--- a/src/main/java/ome/api/Search.java
+++ b/src/main/java/ome/api/Search.java
@@ -547,7 +547,7 @@ public interface Search extends ome.api.StatefulServiceInterface,
      * 
      * Calling this method overrides a previous setting of {@link #and()} or
      * {@link #not()}. If there is no active queries (i.e.
-     * {@link #activeQueries()} > 0), then an {@link ApiUsageException} will be
+     * {@link #activeQueries()} greater than 0), then an {@link ApiUsageException} will be
      * thrown.
      */
     void or();
@@ -571,7 +571,7 @@ public interface Search extends ome.api.StatefulServiceInterface,
      * <p>
      * Calling this method overrides a previous setting of {@link #or()} or
      * {@link #not()}. If there is no active queries (i.e.
-     * {@link #activeQueries()} > 0), then an {@link ApiUsageException} will be
+     * {@link #activeQueries()} greater than 0), then an {@link ApiUsageException} will be
      * thrown.
      * </p>
      */
@@ -595,7 +595,7 @@ public interface Search extends ome.api.StatefulServiceInterface,
      * <p>
      * Calling this method overrides a previous setting of {@link #or()} or
      * {@link #and()}. If there is no active queries (i.e.
-     * {@link #activeQueries()} > 0), then an {@link ApiUsageException} will be
+     * {@link #activeQueries()} greater than 0), then an {@link ApiUsageException} will be
      * thrown.
      * </p>
      */

--- a/src/main/java/ome/api/ServiceInterface.java
+++ b/src/main/java/ome/api/ServiceInterface.java
@@ -1,6 +1,4 @@
 /*
- * ome.api.ServiceInterface
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,8 +9,8 @@ package ome.api;
  * Marker interface representing an OMERO API Interface.
  * 
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 1.0
  * @since OME3.0
  */

--- a/src/main/java/ome/api/StatefulServiceInterface.java
+++ b/src/main/java/ome/api/StatefulServiceInterface.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -17,8 +15,8 @@ import ome.system.EventContext;
  * own passivation/activation logic in the similarly named methods.
  *
  * @author <br>
- *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
+ *         Josh Moore &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:josh.moore@gmx.de"> josh.moore@gmx.de</a>
  * @version 1.0
  * @since OME3.0
  */

--- a/src/main/java/ome/api/ThumbnailStore.java
+++ b/src/main/java/ome/api/ThumbnailStore.java
@@ -93,9 +93,9 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>sizeX</i> > pixels.sizeX</li>
+     *             <li><i>sizeX</i> is greater than pixels.sizeX</li>
      *             <li><i>sizeX</i> is negative</li>
-     *             <li><i>sizeY</i> > pixels.sizeY</li>
+     *             <li><i>sizeY</i> is greater than pixels.sizeY</li>
      *             <li><i>sizeY</i> is negative</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
@@ -122,9 +122,9 @@ public interface ThumbnailStore extends StatefulServiceInterface {
     * @throws ApiUsageException
     *             if:
     *             <ul>
-    *             <li><code>sizeX</code> > pixels.sizeX</li>
+    *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
     *             <li><code>sizeX</code> is negative</li>
-    *             <li><code>sizeY</code> > pixels.sizeY</li>
+    *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
     *             <li><code>sizeY</code> is negative</li>
     *             <li>{@link #setPixelsId} has not yet been called</li>
     *             </ul>
@@ -196,7 +196,7 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>size</i> > pixels.sizeX and pixels.sizeY</li>
+     *             <li><i>size</i> is greater than pixels.sizeX and pixels.sizeY</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
      * @return a JPEG thumbnail byte buffer.
@@ -218,9 +218,9 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>sizeX</i> > pixels.sizeX</li>
+     *             <li><i>sizeX</i> is greater than pixels.sizeX</li>
      *             <li><i>sizeX</i> is negative</li>
-     *             <li><i>sizeY</i> > pixels.sizeY</li>
+     *             <li><i>sizeY</i> is greater than pixels.sizeY</li>
      *             <li><i>sizeY</i> is negative</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
@@ -245,9 +245,9 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>sizeX</i> > pixels.sizeX</li>
+     *             <li><i>sizeX</i> is greater than pixels.sizeX</li>
      *             <li><i>sizeX</i> is negative</li>
-     *             <li><i>sizeY</i> > pixels.sizeY</li>
+     *             <li><i>sizeY</i> is greater than pixels.sizeY</li>
      *             <li><i>sizeY</i> is negative</li>
      *             <li><i>theZ</i> is out of range</li>
      *             <li><i>theT</i> is out of range</li>
@@ -272,7 +272,7 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>size</i> > pixels.sizeX and pixels.sizeY</li>
+     *             <li><i>size</i> is greater than pixels.sizeX and pixels.sizeY</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
      * @return a JPEG thumbnail byte buffer.
@@ -295,7 +295,7 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>size</i> > pixels.sizeX and pixels.sizeY</li>
+     *             <li><i>size</i> is greater than pixels.sizeX and pixels.sizeY</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
      * @return a JPEG thumbnail byte buffer.
@@ -317,9 +317,9 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>sizeX</i> > pixels.sizeX</li>
+     *             <li><i>sizeX</i> is greater than pixels.sizeX</li>
      *             <li><i>sizeX</i> is negative</li>
-     *             <li><i>sizeY</i> > pixels.sizeY</li>
+     *             <li><i>sizeY</i> is greater than pixels.sizeY</li>
      *             <li><i>sizeY</i> is negative</li>
      *             <li>{@link #setPixelsId(long)} has not yet been called</li>
      *             </ul>
@@ -344,7 +344,7 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @throws ApiUsageException
      *             if:
      *             <ul>
-     *             <li><i>size</i> > pixels.sizeX and pixels.sizeY</li>
+     *             <li><i>size</i> is greater than pixels.sizeX and pixels.sizeY</li>
      *             <li><i>size</i> is negative</li>
      *             </ul>
      * @see #createThumbnail(Integer, Integer)

--- a/src/main/java/ome/api/ThumbnailStore.java
+++ b/src/main/java/ome/api/ThumbnailStore.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -24,8 +22,8 @@ import ome.annotations.Validate;
  * </ol>
  * </p>
  * 
- * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
  * @version 3.0
  * @since 3.0
  */

--- a/src/main/java/ome/util/checksum/AbstractChecksumProvider.java
+++ b/src/main/java/ome/util/checksum/AbstractChecksumProvider.java
@@ -33,7 +33,7 @@ import com.google.common.io.Files;
  * Abstract skeleton class implementing {@link ChecksumProvider} and providing
  * implementations of the interface methods using a universal checksum class
  * object. Classes extending this class shall pass in a concrete checksum
- * algorithm implementation (a {@link HashFunction} instance) as the constructor
+ * algorithm implementation (a @see HashFunction instance) as the constructor
  * parameter.
  *
  * @author Blazej Pindelski, bpindelski at dundee.ac.uk
@@ -52,7 +52,7 @@ public class AbstractChecksumProvider implements ChecksumProvider {
     private Optional<String> hashString = Optional.absent();
 
     /**
-     * Protected ctor. There should not be an instance of this class.
+     * Protected constructor. There should not be an instance of this class.
      * @param hashFunction
      */
     protected AbstractChecksumProvider(HashFunction hashFunction) {

--- a/src/main/java/ome/util/checksum/AbstractChecksumProvider.java
+++ b/src/main/java/ome/util/checksum/AbstractChecksumProvider.java
@@ -33,7 +33,7 @@ import com.google.common.io.Files;
  * Abstract skeleton class implementing {@link ChecksumProvider} and providing
  * implementations of the interface methods using a universal checksum class
  * object. Classes extending this class shall pass in a concrete checksum
- * algorithm implementation (a @see HashFunction instance) as the constructor
+ * algorithm implementation (a {@link HashFunction} instance) as the constructor
  * parameter.
  *
  * @author Blazej Pindelski, bpindelski at dundee.ac.uk

--- a/src/main/java/ome/util/checksum/ChecksumProvider.java
+++ b/src/main/java/ome/util/checksum/ChecksumProvider.java
@@ -29,7 +29,7 @@ import java.nio.ByteBuffer;
  * make sure calls to {@link ChecksumProvider#putFile(String)} are not intermixed
  * with <code>putBytes()</code>. This object can only return a checksum for
  * a file or byte structure, never both.
- * <br/>
+ * <br>
  * Inside the <code>ome.util.checksum</code> package, the term <i>checksum</i>
  * is understood as an "umbrella" term covering checksums, message digests and
  * hashes.

--- a/src/main/java/ome/util/logback/SiftingWhileRejectingDefaultAppender.java
+++ b/src/main/java/ome/util/logback/SiftingWhileRejectingDefaultAppender.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package ome.util.logback;
 
 import ch.qos.logback.classic.sift.SiftingAppender;

--- a/src/main/java/ome/util/search/InvalidQueryException.java
+++ b/src/main/java/ome/util/search/InvalidQueryException.java
@@ -22,8 +22,8 @@ package ome.util.search;
 /**
  * Exception to indicate that the query string was invalid
  * 
- * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  * 
  * @since 5.0
  */

--- a/src/main/java/ome/util/search/LuceneQueryBuilder.java
+++ b/src/main/java/ome/util/search/LuceneQueryBuilder.java
@@ -41,12 +41,12 @@ import java.util.regex.Pattern;
  * description:c) AND (name:d description:d)) <br>
  * <br>
  * 
- * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  * 
  * @since 5.0
  * 
- * TODO: For versions > 5.0 this class can be moved from commons to the server
+ * TODO: For versions greater than 5.0 this class can be moved from commons to the server
  */
 public class LuceneQueryBuilder {
 

--- a/src/main/java/omeis/providers/re/RGBAIntBuffer.java
+++ b/src/main/java/omeis/providers/re/RGBAIntBuffer.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.RGBBuffer
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,11 +12,11 @@ import java.util.Arrays;
  * packed integer in the format RGBA. Note that Java color objects are 
  * stored in ARGB.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/RGBBuffer.java
+++ b/src/main/java/omeis/providers/re/RGBBuffer.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.RGBBuffer
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,11 +12,11 @@ import java.util.Arrays;
  * Holds the data of an <i>RGB</i> image. The image data is stored in three
  * byte arrays, one for each color band.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/RGBIntBuffer.java
+++ b/src/main/java/omeis/providers/re/RGBIntBuffer.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.RGBBuffer
- *
  *   Copyright 2006-2015 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -15,11 +13,11 @@ import com.google.common.math.IntMath;
  * Holds the data of an <i>RGB</i> image. The image data is stored in three
  * byte arrays, one for each color band.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/RenderingEngine.java
+++ b/src/main/java/omeis/providers/re/RenderingEngine.java
@@ -45,11 +45,11 @@ import omeis.providers.re.data.PlaneDef;
  * </p>
  * 
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */
@@ -126,7 +126,7 @@ public interface RenderingEngine extends StatefulServiceInterface {
      *   <li><code>timepoint</code> is out of range</li>
      *   <li><code>start</code> is out of range</li>
      *   <li><code>end</code> is out of range</li>
-     *   <li><code>start > end</code></li>
+     *   <li><code>start</code> is greater than <code>end</code></li>
      * </ul>
      * @see ome.api.IProjection#projectPixels(long, PixelsType, int, int, int, List, int, int, int, String)
      */
@@ -155,7 +155,7 @@ public interface RenderingEngine extends StatefulServiceInterface {
      *   <li><code>timepoint</code> is out of range</li>
      *   <li><code>start</code> is out of range</li>
      *   <li><code>end</code> is out of range</li>
-     *   <li><code>start > end</code></li>
+     *   <li><code>start</code> is greater than <code>end</code></li>
      * </ul>
      * @see ome.api.IProjection#projectPixels(long, PixelsType, int, int, int, List, int, int, int, String)
      */

--- a/src/main/java/omeis/providers/re/codomain/CodomainMap.java
+++ b/src/main/java/omeis/providers/re/codomain/CodomainMap.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.CodomainMap
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -22,11 +20,11 @@ package omeis.providers.re.codomain;
  * </p>
  * 
  * @see CodomainMapContext
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/CodomainMapContext.java
+++ b/src/main/java/omeis/providers/re/codomain/CodomainMapContext.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.CodomainMapContext
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,11 +9,11 @@ package omeis.providers.re.codomain;
  * Each concrete subclass defines transformation parameters for a
  * {@link CodomainMap} implementation.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/ContrastStretchingContext.java
+++ b/src/main/java/omeis/providers/re/codomain/ContrastStretchingContext.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.ContrastStretchingContext
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -15,11 +13,11 @@ package omeis.providers.re.codomain;
  * (xStart, yStart) and (xEnd, yEnd). The third one between (xEnd, yEnd) and
  * (intervalEnd, intervalEnd).
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/ContrastStretchingMap.java
+++ b/src/main/java/omeis/providers/re/codomain/ContrastStretchingMap.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.ContrastStretchingMap
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -14,11 +12,11 @@ package omeis.providers.re.codomain;
  * {@link ContrastStretchingContext}) determine the equation of the linear
  * functions.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/IdentityMapContext.java
+++ b/src/main/java/omeis/providers/re/codomain/IdentityMapContext.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.IdentityMapContext
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,11 +8,11 @@ package omeis.providers.re.codomain;
 /**
  * An empty context for the identity map.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/PlaneSlicingContext.java
+++ b/src/main/java/omeis/providers/re/codomain/PlaneSlicingContext.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.PlaneSlicingDef
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -13,11 +11,11 @@ package omeis.providers.re.codomain;
  * bit-plane <code>7</code> for the most significant bit. The BIT_* constants
  * cannot be modified b/c they have a meaning.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *          <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/codomain/ReverseIntensityContext.java
+++ b/src/main/java/omeis/providers/re/codomain/ReverseIntensityContext.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.codomain.ReverseIntensityContext
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -10,11 +8,11 @@ package omeis.providers.re.codomain;
 /**
  * The empty context of the reverse intensity map.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *          <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *          <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  * 

--- a/src/main/java/omeis/providers/re/data/PlaneDef.java
+++ b/src/main/java/omeis/providers/re/data/PlaneDef.java
@@ -1,6 +1,4 @@
 /*
- * omeis.providers.re.data.PlaneDef
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -15,11 +13,11 @@ import java.util.List;
  * Identifies a <i>2D</i>-plane in the <i>XYZ</i> moving frame of the <i>3D</i>
  * stack. Tells which plane the wavelengths to render belong to.
  * 
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author <br>
- *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
+ *         Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */

--- a/src/main/java/omeis/providers/re/lut/LutProvider.java
+++ b/src/main/java/omeis/providers/re/lut/LutProvider.java
@@ -29,7 +29,7 @@ import ome.model.display.ChannelBinding;
 
 /**
  * Interface for lookup table providers.
- * @author Chris Allan <callan@glencoesoftware.com>
+ * @author Chris Allan callan@glencoesoftware.com
  * @since 5.4.1
  */
 public interface LutProvider extends ServiceInterface {

--- a/src/test/java/ome/testing/Paths.java
+++ b/src/test/java/ome/testing/Paths.java
@@ -54,7 +54,7 @@ public class Paths {
     /**
      * 
      * @param data
-     *            List of the form List<Map<String,Long>> where the keys of
+     *            List of the form {@code List<Map<String,Long>>} where the keys of
      *            the map are "cg", "c", and "i". Data of this form can be
      *            retrieved from {@link OMEData#get(String)} with the string
      *            "CGCPaths.all" TODO


### PR DESCRIPTION
fix javadoc warnings
In order to see if some warnings remain, you will need to use Java version > 1.8 (tested with Java 11)
Currently no warnings are returned if Java 1.8 is used
To check run ``gradle javadoc``