### PR TITLE
Move repository location properties.

### DIFF
--- a/src/main/resources/omero-common.properties
+++ b/src/main/resources/omero-common.properties
@@ -16,9 +16,6 @@
 ##
 ## Properties marked with "DEVELOPMENT" should not be used in production.
 
-omero.data.dir=/OMERO/
-omero.managed.dir=${omero.data.dir}/ManagedRepository
-
 #########################################################
 ## Security settings
 #########################################################


### PR DESCRIPTION
Corresponds to https://github.com/ome/omero-model/pull/29 which is the new home of the removed properties:

- `omero.data.dir`
- `omero.managed.dir`