### PR TITLE
Expand user session creation abilities

### DIFF
--- a/src/main/resources/ome/config.xml
+++ b/src/main/resources/ome/config.xml
@@ -265,6 +265,27 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <!--  SESSION PROPERTIES -->
+    <bean class="ome.system.Preference" id="omero.sessions.timeout">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.maximum">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.max_user_time_to_idle">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
+    <bean class="ome.system.Preference" id="omero.sessions.max_user_time_to_live">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>


### PR DESCRIPTION
The following properties have been exposed to the via the configuration
service so that a user may make predictable and informed choices during
session creation:

 * `omero.sessions.timeout`
 * `omero.sessions.maximum`
 * `omero.sessions.max_user_time_to_idle`
 * `omero.sessions.max_user_time_to_live`
