### PR TITLE
Add `omero.pixeldata.max_projection_bytes` to dependency stack

### DIFF
--- a/src/main/resources/ome/config.xml
+++ b/src/main/resources/ome/config.xml
@@ -179,6 +179,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.pixeldata.max_projection_bytes">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!--  CLIENT PROPERTIES -->
     <bean class="ome.system.Preference" id="omero.client.scripts_to_ignore">
        <property name="db" value="false"/>


### PR DESCRIPTION
Further to discussion with @jburel on ome/omero-web#115, adding the future property to the bottom of the dependency stack for later use.