### PR TITLE
Prepare build for releasing OMERO 5.6.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "org.openmicroscopy"
-version = "5.5.7-SNAPSHOT"
+version = "5.5.7"
 
 repositories {
     mavenLocal()
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("com.jamonapi:jamon:2.81")
 
-    api("org.openmicroscopy:omero-model:5.6.1")
+    api("org.openmicroscopy:omero-model:5.6.2")
     implementation("com.codahale.metrics:metrics-graphite:3.0.2")
     implementation("com.codahale.metrics:metrics-jvm:3.0.2")
     implementation("com.codahale.metrics:metrics-logback:3.0.2")


### PR DESCRIPTION
Adjust build to correspond with latest release notes in #26.

--exclude for now