### PR TITLE
Add method to get pixel min max

### DIFF
--- a/src/main/java/ome/api/IRenderingSettings.java
+++ b/src/main/java/ome/api/IRenderingSettings.java
@@ -337,4 +337,10 @@ public interface IRenderingSettings extends ServiceInterface {
 	 */
 	void setOriginalSettingsForPixels(@NotNull long pixelsId);
 
+	/**
+	 * Get the minimum and maximum allowed pixel value
+	 * @param pixelId The Id of the <code>Pixels</code> set.
+	 * @return The minimum and maximum as double array
+	 */
+	double[] getPixelMinMax(@NotNull long pixelId);
 }


### PR DESCRIPTION
Make the method https://github.com/ome/omero-renderer/blob/c17065f519ae842378a1bebccb6c35fbeeba5da7/src/main/java/omeis/providers/re/metadata/StatsFactory.java#L222 accessible in the RenderingSettingsService.