### PR TITLE
Add float override config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("com.jamonapi:jamon:2.81")
 
-    api("org.openmicroscopy:omero-model:5.6.5")
+    api("org.openmicroscopy:omero-model:5.6.6-SNAPSHOT")
     implementation("com.codahale.metrics:metrics-graphite:3.0.2")
     implementation("com.codahale.metrics:metrics-jvm:3.0.2")
     implementation("com.codahale.metrics:metrics-logback:3.0.2")

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("com.jamonapi:jamon:2.81")
 
-    api("org.openmicroscopy:omero-model:5.6.6-SNAPSHOT")
+    api("org.openmicroscopy:omero-model:5.6.5")
     implementation("com.codahale.metrics:metrics-graphite:3.0.2")
     implementation("com.codahale.metrics:metrics-jvm:3.0.2")
     implementation("com.codahale.metrics:metrics-logback:3.0.2")

--- a/src/main/resources/ome/config.xml
+++ b/src/main/resources/ome/config.xml
@@ -189,6 +189,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.pixeldata.max_plane_float_override">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.pixeldata.max_tile_length">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>


### PR DESCRIPTION
See https://github.com/ome/omero-model/pull/81
Fixes ome/omero-romio#36
Makes the config variable visible globally