### PR TITLE
Workflows and dependencies updates

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,31 +9,22 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        java: [1.8, 11]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    env:
-      gradle_version: 6.8.3 # set to empty to build with most recent version of gradle
-      gradle_commands: build # default is build
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Wrap with specified version
-        run: gradle wrapper --gradle-version=${{ env.gradle_version }}
-        if: ${{ env.gradle_version != '' }}
-      - name: Wrap without version
-        run: gradle wrapper
-        if: ${{ env.gradle_version == '' }}
-      - name: Run commands
-        run: ./gradlew ${{ env.gradle_commands }}
+    uses: ome/action-workflows/.github/workflows/gradle_build.yml@v1
+  publish_snapshots:
+    if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'ome' }}
+    needs: build
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v1
+    with:
+      ARTIFACTORY_URL: "snapshots"
+    secrets:
+      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+  publish:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags') && github.repository_owner == 'ome'
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v1
+    with:
+      ARTIFACTORY_URL: "staging"
+    secrets:
+      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("com.jamonapi:jamon:2.81")
 
-    api("org.openmicroscopy:omero-model:5.6.5")
+    api("org.openmicroscopy:omero-model:5.6.7")
     implementation("com.codahale.metrics:metrics-graphite:3.0.2")
     implementation("com.codahale.metrics:metrics-jvm:3.0.2")
     implementation("com.codahale.metrics:metrics-logback:3.0.2")

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java-library"
-    id "org.openmicroscopy.project" version "5.5.1"
+    id "org.openmicroscopy.project" version "5.5.4"
 }
 
 group = "org.openmicroscopy"


### PR DESCRIPTION
- update Gradle workflow to publish SNAPSHOTS and release
- bump `org.openmicroscopy.org` plugin to consume version 5.5.4
- bump `org.openmicroscopy:ome-model` to version 5.6.7