### PR TITLE
Allow `omero.server.nodedescriptors` to be queried from a client

### DIFF
--- a/src/main/resources/ome/config.xml
+++ b/src/main/resources/ome/config.xml
@@ -113,6 +113,11 @@
         <property name="mutable" value="false"/>
         <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.server.nodedescriptors">
+        <property name="db" value="false"/>
+        <property name="mutable" value="false"/>
+        <property name="visibility" value="all"/>
+    </bean>
     <!--  DATABASE PROPERTIES -->
     <bean class="ome.system.Preference" id="omero.db.authority">
        <property name="db" value="true"/>


### PR DESCRIPTION
It is useful for clients to know that specific services are disabled. In particular `PixelData-0` for warning users about a lack of pyramid generation or `Tables-0` for warning users about OMERO.tables services being unavailable.

/cc @sbesson, @stick, @atTODO