### PR TITLE
Define omero.qa.feedback as new visible server property

### DIFF
--- a/src/main/resources/ome/config.xml
+++ b/src/main/resources/ome/config.xml
@@ -68,6 +68,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.qa.feedback">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <bean class="ome.system.Preference" id="omero.data.dir">
        <property name="mutable" value="true"/>
     </bean>

--- a/src/main/resources/omero-common.properties
+++ b/src/main/resources/omero-common.properties
@@ -83,6 +83,12 @@ omero.security.trustStorePassword=
 omero.upgrades.url=http://upgrade.openmicroscopy.org.uk
 
 #############################################
+## QA configuration
+#############################################
+# Base URL to use when sending feedback (errors, comments)
+omero.qa.feedback=http://qa.openmicroscopy.org.uk
+
+#############################################
 ## cluster configuration
 ##
 ## For more information, see


### PR DESCRIPTION
Similarly to `omero.upgrades.url`, this property allows connected clients to access the server configuration and direct QA feedback accordingly.

At the moment, OMERO.web is the main client which defines a similar mechanism in https://github.com/ome/omero-web/blob/master/omeroweb/settings.py#L267

The name and default value of the server property are kept identical to the ones in the OMERO.web setting. Practically, a combined OMERO.server/OMERO.web deployment overriding the default value of `omero.qa.feedback` to use an alternate QA endpoint, there should be no configuration change and other clients can start retrieving the value of `omero.qa.feedback` and using it internally.

Initially, the primary target of this work will be OMERO.insight (a companion PR will be opened shortly). The importer is another client that could be updated in the mid-term to use the new configuration.
