### PR TITLE
Mark omero.security.ignore_case as production property

### DIFF
--- a/src/main/resources/omero-common.properties
+++ b/src/main/resources/omero-common.properties
@@ -38,7 +38,6 @@ omero.security.password_provider=chainedPasswordProvider
 # to interact with the server.
 omero.security.password_required=true
 
-# DEVELOPMENT: currently undergoing internal testing
 # Whether to ignore the case of the username during login (`true` or
 # `false`). Default: `false` (JSmith and jsmith will be considered two
 # different users).


### PR DESCRIPTION
The usage of this property is documented in the LDAP section  https://omero.readthedocs.io/en/stable/sysadmins/server-ldap.html#case-sensitivity. As it still marked as `DEVELOPMENT` in the properties file, it is hidden the generated configuration glossary in the [OMERO documentation](https://omero.readthedocs.io/en/stable/sysadmins/config.html#security).
