### PR TITLE
Do not hide "Make Movie" from script menu

### DIFF
--- a/src/main/resources/omero-common.properties
+++ b/src/main/resources/omero-common.properties
@@ -150,7 +150,7 @@ omero.client.web.host=
 omero.client.scripts_to_ignore=/omero/figure_scripts/Movie_Figure.py,\
 /omero/figure_scripts/Split_View_Figure.py,\
 /omero/figure_scripts/Thumbnail_Figure.py,\
-/omero/figure_scripts/ROI_Split_Figure.py,/omero/export_scripts/Make_Movie.py,\
+/omero/figure_scripts/ROI_Split_Figure.py,\
 /omero/import_scripts/Populate_ROI.py
 
 # Flag to show/hide "Orphaned images" container. Only accept "true" or "false"


### PR DESCRIPTION
Assuming that the [OMERO.movie][1] documentation is actually referring to the script called `Make_Movie.py`, which the detailed description suggests, I can only assume that this entry has been added accidentally to the "scripts_to_ignore" list (which would also explain why it is the only entry that's not placed on a separate line).

Since we're having several users that are relying quite heavily on the "Make Movie" script, and we can't see an obvious reason why this script should be hidden, we'd like to ask to "unhide" it.

In case that's accepted, we'd also have several improvements for the script ready (more or less), including support for multiple images and improvements on the resulting movie's name. Obviously we'd prefer to contribute those improvements back to the community, but this only makes sense if the script is actually reachable through the client's menu.

[1]: https://omero.readthedocs.io/en/stable/sysadmins/omeromovie.html